### PR TITLE
Return stream id on auth, split store.SetActive

### DIFF
--- a/main.go
+++ b/main.go
@@ -84,15 +84,15 @@ func PublishHandler(store *Store) handleFunc {
 
 		log.Printf("publish %s/%s auth: '%s'\n", app, name, auth)
 
-		success := store.Auth(app, name, auth)
+		success, id := store.Auth(app, name, auth)
 		if !success {
-			log.Printf("Publish %s/%s unauthorized\n", app, name)
+			log.Printf("Publish %s %s/%s unauthorized\n", id, app, name)
 			http.Error(w, "401 Unauthorized", http.StatusUnauthorized)
 			return
 		}
 
-		store.SetActive(app, name, true)
-		log.Printf("Publish %s/%s ok\n", app, name)
+		store.SetActive(id)
+		log.Printf("Publish %s %s/%s ok\n", id, app, name)
 	}
 }
 


### PR DESCRIPTION
This commit makes the Auth function return the published streams id.
The reason behind this is simply that this is the only point, where its
possible to gather which stream is actually beeing published, because the
server reveals the publishers authkey at this point.

With this change its also possible to set the streams active flag by its
id. Deactivation on unpublishing can only be done by looking at the
streams Application/Name Pair and thus the SetActive function is split
into SetActive(id) which can is called by the streams id and
SetInactive(app, name) which sets all known streams for that app/name
pair as not active.