### PR TITLE
Frontend stream blocking

### DIFF
--- a/main.go
+++ b/main.go
@@ -84,15 +84,15 @@ func PublishHandler(store *Store) handleFunc {
 
 		log.Printf("publish %s/%s auth: '%s'\n", app, name, auth)
 
-		success := store.Auth(app, name, auth)
+		success, id := store.Auth(app, name, auth)
 		if !success {
-			log.Printf("Publish %s/%s unauthorized\n", app, name)
+			log.Printf("Publish %s %s/%s unauthorized\n", id, app, name)
 			http.Error(w, "401 Unauthorized", http.StatusUnauthorized)
 			return
 		}
 
-		store.SetActive(app, name, true)
-		log.Printf("Publish %s/%s ok\n", app, name)
+		store.SetActive(id)
+		log.Printf("Publish %s %s/%s ok\n", id, app, name)
 	}
 }
 
@@ -108,7 +108,7 @@ func UnpublishHandler(store *Store) handleFunc {
 		app := r.PostForm.Get("app")
 		name := r.PostForm.Get("name")
 
-		store.SetActive(app, name, false)
+		store.SetInactive(app, name)
 		log.Printf("Unpublish %s/%s ok\n", app, name)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -195,6 +195,43 @@ func RemoveHandler(store *Store) handleFunc {
 	}
 }
 
+func BlockHandler(store *Store) handleFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var errs []error
+		id := r.PostFormValue("id")
+		state, _ := strconv.ParseBool(r.PostFormValue("blocked"))
+		newstate, action := func(bool) (bool, string) { if state == true { return false, "unblock"} else {return true, "block"}}(state)
+
+		// Get Application/Name for stream id
+		var app, name string
+		for _, stream := range store.State.Streams {
+			if stream.Id == id {
+				app = stream.Application
+				name = stream.Name
+			}
+		}
+
+		err := store.SetBlocked(id, newstate)
+		log.Printf("%ved Stream %v (%v/%v)", action, id, app, name)
+		if err != nil {
+			log.Println(err)
+			errs = append(errs, fmt.Errorf("Failed to %v stream %v (%v/%v)", action, id, app, name))
+
+			data := TemplateData{
+				Store:        store.Get(),
+				CsrfTemplate: csrf.TemplateField(r),
+				Errors:       errs,
+			}
+			err = templates.ExecuteTemplate(w, "form.html", data)
+			if err != nil {
+				log.Println("Template failed", err)
+			}
+		} else {
+			http.Redirect(w, r, "/", http.StatusSeeOther)
+		}
+	}
+}
+
 func main() {
 	var path = flag.String("store", "store.db", "Path to store file")
 	var apps = flag.String("app", "stream", "Comma separated list of RTMP applications")
@@ -225,6 +262,7 @@ func main() {
 	sub.Path("/").Methods("GET").HandlerFunc(FormHandler(store))
 	sub.Path("/add").Methods("POST").HandlerFunc(AddHandler(store))
 	sub.Path("/remove").Methods("POST").HandlerFunc(RemoveHandler(store))
+	sub.Path("/block").Methods("POST").HandlerFunc(BlockHandler(store))
 	sub.PathPrefix("/public/").Handler(
 		http.StripPrefix(*prefix+"/public/", http.FileServer(statikFS)))
 

--- a/public/main.css
+++ b/public/main.css
@@ -20,6 +20,10 @@ table td::before {
 	margin-right: 1rem;
 }
 
+table td {
+	border-top-color: var(--table-border-separator-color);
+}
+
 button {
 	margin: calc(var(--universal-margin) / 2);
 }

--- a/public/main.css
+++ b/public/main.css
@@ -61,6 +61,10 @@ td[data-label='Auth'] .authKey{
 	margin-left: auto;
 }
 
+td[data-label='Blocked'] {
+	line-height: 2.5;
+}
+
 td[data-label='Notes'], th[data-label='Notes']{
 	flex: 2 !important;
 }

--- a/storage/storage.proto
+++ b/storage/storage.proto
@@ -14,4 +14,5 @@ message Stream {
     int64 auth_expire = 5;
     string id = 6;
     string notes = 7;
+    bool blocked = 8;
 }

--- a/store.go
+++ b/store.go
@@ -84,6 +84,23 @@ func (store *Store) SetInactive(app string, name string) bool {
 	return false
 }
 
+// SetBlocked changes a streams blocked state
+func (store *Store) SetBlocked(id string, state bool) error {
+	store.Lock()
+	defer store.Unlock()
+
+	for _, stream := range store.State.Streams {
+		if stream.Id == id {
+			stream.Blocked = state
+			if err := store.save(); err != nil {
+				return err
+			}
+			return nil
+		}
+	}
+	return nil
+}
+
 func (store *Store) AddStream(stream *storage.Stream) error {
 	store.Lock()
 	defer store.Unlock()
@@ -94,6 +111,7 @@ func (store *Store) AddStream(stream *storage.Stream) error {
 	}
 
 	stream.Id = id.String()
+	stream.Blocked = false;
 	store.State.Streams = append(store.State.Streams, stream)
 
 	if err := store.save(); err != nil {

--- a/store.go
+++ b/store.go
@@ -38,11 +38,28 @@ func NewStore(path string, apps []string, prefix string) (*Store, error) {
 	return store, nil
 }
 
-func (store *Store) Auth(app string, name string, auth string) bool {
+func (store *Store) Auth(app string, name string, auth string) (success bool, id string) {
 	store.RLock()
 	defer store.RUnlock()
 	for _, stream := range store.State.Streams {
-		if stream.Application == app && stream.Name == name && stream.AuthKey == auth {
+		if stream.Application == app && stream.Name == name && stream.AuthKey == auth && stream.Blocked == false {
+			return true, stream.Id
+		}
+	}
+
+	return false, ""
+}
+
+// SetActive sets a stream to active state by its id, returns success
+func (store *Store) SetActive(id string) bool {
+	store.Lock()
+	defer store.Unlock()
+	for _, stream := range store.State.Streams {
+		if stream.Id == id {
+			stream.Active = true
+			if err := store.save(); err != nil {
+				log.Println(err)
+			}
 			return true
 		}
 	}
@@ -50,13 +67,13 @@ func (store *Store) Auth(app string, name string, auth string) bool {
 	return false
 }
 
-// SetActive changes a streams active state, returns success
-func (store *Store) SetActive(app string, name string, state bool) bool {
+// SetInactive unsets the active state for all streams defined for app/name, returns success
+func (store *Store) SetInactive(app string, name string) bool {
 	store.Lock()
 	defer store.Unlock()
 	for _, stream := range store.State.Streams {
 		if stream.Application == app && stream.Name == name {
-			stream.Active = state
+			stream.Active = false
 			if err := store.save(); err != nil {
 				log.Println(err)
 			}

--- a/template.go
+++ b/template.go
@@ -40,6 +40,7 @@ var templates = template.Must(template.New("form.html").Parse(
       <thead>
         <th>Name</th>
         <th data-label="Auth">Auth</th>
+        <th data-label="Blocked">Blocked</th>
         <th>Expires</th>
         <th data-label="Notes">Notes</th>
         <th></th>
@@ -55,6 +56,14 @@ var templates = template.Must(template.New("form.html").Parse(
           </td>
           <td data-label="Auth">
             <input class="authKey" size="5" value="{{.AuthKey}}" readonly/><button class="secondary copyToClipboard inputAddon">Copy</button>
+          </td>
+          <td data-label="Blocked">
+            <form class="inline" action="{{$.Store.Prefix}}/block" method="POST" novalidate>
+              {{ $.CsrfTemplate }}
+              <input type="hidden" name="id" value="{{.Id}}">
+              <input type="hidden" name="blocked" value="{{.Blocked}}">
+              <input type="checkbox" oninput="this.form.submit();"{{if eq .Blocked true}} checked{{end}}>
+            </form>
           </td>
           <td data-label="Expire" data-expire="{{.AuthExpire}}">
             {{if eq .AuthExpire -1}}

--- a/template.go
+++ b/template.go
@@ -11,7 +11,7 @@ type TemplateData struct {
 }
 
 var templates = template.Must(template.New("form.html").Parse(
-	`<!DOCTYPE html>
+`<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
@@ -41,7 +41,7 @@ var templates = template.Must(template.New("form.html").Parse(
         <th>Name</th>
         <th data-label="Auth">Auth</th>
         <th>Expires</th>
-		    <th data-label="Notes">Notes</th>
+        <th data-label="Notes">Notes</th>
         <th></th>
       </thead>
       <tbody>


### PR DESCRIPTION
This patch series adds the possibility to temporarily block streams in the frontend without removing them.

It also fixes a problem with the live marker being set on the first stream for a given application/name pair not the stream actually published with its auth key.

Another change makes the browser return to the frontends root page after successfull form submits via 303 Redirects.